### PR TITLE
v2.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
-## Version 2.15.0 [2026-01-05]
+## Version 2.15.1 [2026-03-06]
+- Akemashita Omedato! HNY 2026!
 - Added check for ffmpeg and minimum version requirement.
 - KissKhClient: Fix #73: Bug while loading domain of HLS Child links.
+- Added new CLI option `-D` or `--debug` to enable debug logging directly from the CLI. This overrides the setting in the configuration file.
+- Fix #80: Update the git url in the backend for changelog info.
 
 ## Version 2.14.9 [2025-09-19]
 - AnimePaheClient: Updated domain.

--- a/Utils/commons.py
+++ b/Utils/commons.py
@@ -84,8 +84,8 @@ class VersionManager():
         '''
         latest_changelog = {}
         try:
-            response = requests.get('https://github.com/Prudhvi-pln/udb/blob/main/CHANGELOG.md?plain=1', headers={'Accept': 'application/json'}).json()['payload']['blob']['rawLines']
-            latest_changelog = self._convert_md_to_json(response)
+            response = requests.get('https://raw.githubusercontent.com/Prudhvi-pln/udb/main/CHANGELOG.md').text
+            latest_changelog = self._convert_md_to_json(response.splitlines())
         except Exception as e:
             pass
 

--- a/udb.py
+++ b/udb.py
@@ -313,6 +313,7 @@ if __name__ == '__main__':
         parser.add_argument('-c', '--conf', default='config_udb.yaml',
                             help='configuration file for UDB client (default: config_udb.yaml)')
         parser.add_argument('-H', '--hidden', default=False, action='store_true', help='show hidden clients')
+        parser.add_argument('-D', '--debug', default=False, action='store_true', help='enable debug logging')
         parser.add_argument('-l', '--log-file', help='custom file name for logging (default: udb_{YYYYMMDDHHMMSS}.log)')
         parser.add_argument('-v', '--version', default=False, action='store_true', help='display current version of UDB')
         parser.add_argument('-s', '--series-type', type=int, help='type of series')
@@ -331,6 +332,7 @@ if __name__ == '__main__':
         args = parser.parse_args()
         config_file = args.conf
         show_hidden_clients = args.hidden
+        enable_debug_logging = args.debug
         log_file_name = args.log_file
         # set the log_file_name
         if log_file_name is None:
@@ -382,6 +384,7 @@ if __name__ == '__main__':
 
         # create logger
         config['LoggerConfig']['log_file_name'] = log_file_name
+        if enable_debug_logging: config['LoggerConfig']['log_level'] = 'DEBUG'
         # print(f'Current log: {log_file_name}')
         logger = create_logger(**config['LoggerConfig'])
         logger.info(f'-------------------------------- NEW UDB INSTANCE v{__version__} --------------------------------')


### PR DESCRIPTION
## Version 2.15.1 [2026-03-06]
- Akemashita Omedato! HNY 2026!
- Added check for ffmpeg and minimum version requirement.
- KissKhClient: Fix #73: Bug while loading domain of HLS Child links.
- Added new CLI option `-D` or `--debug` to enable debug logging directly from the CLI. This overrides the setting in the configuration file.
- Fix #80: Update the git url in the backend for changelog info.
